### PR TITLE
Hotfix/issue403

### DIFF
--- a/gradle/gradle/plugins.settings.gradle
+++ b/gradle/gradle/plugins.settings.gradle
@@ -13,12 +13,17 @@
 
 rootProject.projectDir = file('../../../core')
 
-include 'syncany'
+
+//Not needed and breaks sonar
+//include 'syncany'
+
 include 'syncany-lib'
 include 'syncany-cli'
 include 'syncany-util'
 
-project(':syncany').projectDir = file('../../../core')
+//Not needed and breaks sonar
+//project(':syncany').projectDir = file('../../../core') 
+
 project(':syncany-lib').projectDir = file('../../../core/syncany-lib')
 project(':syncany-cli').projectDir = file('../../../core/syncany-cli')
 project(':syncany-util').projectDir = file('../../../core/syncany-util')


### PR DESCRIPTION
```
[16:56:36] <MrHug> Problems seem to arise from the gradle/gradle/plugins.settings.gradle script
[16:56:43] <MrHug> In here you do:
[16:57:15] <MrHug> rootProject.projectDir = file('../../../core') 
[16:57:15] <MrHug> But also: include 'syncany' 
[16:57:15] <MrHug> project(':syncany').projectDir = file('../../../core')  
[16:57:48] <MrHug> As a result the build.gradle file of the core is loaded twice and this leads to the issue Christian noticed
[16:58:33] <MrHug> If I comment out the "include 'syncany'" and "project().foo = file(...)" stuff I seem to be able to compile the plug-in just fine though :P
[16:58:42] <MrHug> So I was wondering why that is even there
[17:00:37] <aureianimus> can you check if it still works if you delete core/build?
[17:00:45] <aureianimus> (or clean)
[17:00:52] <MrHug> I've run gradlew clean before trying it
[17:01:41] <MrHug> I should note that the plugins.settings.gradle script does still include the util, lib and cli projects, just not the overarching syncany one :P
[17:03:32] <aureianimus> well, in that case, i don't know why it's there either
[17:04:10] <MrHug> In that case what do you recommend? Wait for binwiederhier to show up here, or just make a PR and have him comment there?
[17:04:36] <aureianimus> i'd make the PR
[17:04:47] <aureianimus> that way we can at least see if travis agrees
```

So here is the PR for the Travis test :wink:
