### PR TITLE
Make URI creation more predictable

### DIFF
--- a/src/main/java/org/syncany/plugins/dropbox/DropboxTransferManager.java
+++ b/src/main/java/org/syncany/plugins/dropbox/DropboxTransferManager.java
@@ -84,12 +84,12 @@ public class DropboxTransferManager extends AbstractTransferManager {
 	public DropboxTransferManager(DropboxTransferSettings settings, Config config) {
 		super(settings, config);
 
-		this.path = URI.create("/" + settings.getPath()).normalize();
-		this.multichunksPath = createUri(this.path, "multichunks");
-		this.databasesPath = createUri(this.path, "databases");
-		this.actionsPath = createUri(this.path, "actions");
-		this.transactionsPath = createUri(this.path, "transactions");
-		this.tempPath = createUri(this.path, "temporary");
+		this.path = UriBuilder.fromRoot("/").toChild(settings.getPath()).build();
+		this.multichunksPath = UriBuilder.fromRoot("/").toChild(settings.getPath()).toChild("multichunks").build();
+		this.databasesPath = UriBuilder.fromRoot("/").toChild(settings.getPath()).toChild("databases").build();
+		this.actionsPath = UriBuilder.fromRoot("/").toChild(settings.getPath()).toChild("actions").build();
+		this.transactionsPath = UriBuilder.fromRoot("/").toChild(settings.getPath()).toChild("transactions").build();
+		this.tempPath = UriBuilder.fromRoot("/").toChild(settings.getPath()).toChild("temporary").build();
 
 		this.client = new DbxClient(DropboxTransferPlugin.DROPBOX_REQ_CONFIG, settings.getAccessToken());
 	}
@@ -388,14 +388,6 @@ public class DropboxTransferManager extends AbstractTransferManager {
 			logger.log(Level.INFO, "testRepoFileExists: Exception when trying to check repo file existence.", e);
 			return false;
 		}
-	}
-
-	private URI createUri(URI parent, String child) {
-		if (!parent.toString().endsWith("/")) {
-			parent = URI.create(parent.toString() + "/");
-		}
-
-		return parent.resolve(child);
 	}
 
 }

--- a/src/main/java/org/syncany/plugins/dropbox/UriBuilder.java
+++ b/src/main/java/org/syncany/plugins/dropbox/UriBuilder.java
@@ -1,0 +1,66 @@
+package org.syncany.plugins.dropbox;
+
+import java.net.URI;
+import java.util.List;
+
+import org.syncany.util.StringUtil;
+import com.google.common.collect.Lists;
+
+/**
+ * @author Christian Roth <christian.roth@port17.de>
+ */
+
+public class UriBuilder {
+
+	public static final String SEPARATOR = "/";
+
+	private final String root;
+	private final List<String> children = Lists.newArrayList();
+	private boolean endingSeparator = false;
+
+	public static UriBuilder fromRoot(String root) {
+		return new UriBuilder(root);
+	}
+
+	private UriBuilder(String root) {
+		this.root = root;
+	}
+
+	public UriBuilder toChild(String child) {
+		children.add(child);
+
+		return this;
+	}
+
+	public UriBuilder withEndingSeparator() {
+		endingSeparator = true;
+
+		return this;
+	}
+
+	public URI build() {
+		String fullPath = root;
+
+		if (children.size() > 0) {
+			fullPath = fullPath + SEPARATOR + StringUtil.join(children, SEPARATOR);
+		}
+
+		if (endingSeparator) {
+			fullPath = fullPath + SEPARATOR;
+		}
+
+		return URI.create(cleanString(fullPath)).normalize();
+	}
+
+	private String cleanString(String toClean) {
+		toClean = toClean.replaceAll("\\\\", "/");
+		toClean = toClean.replaceAll("/{2,}", "/");
+
+		if (!endingSeparator) {
+			toClean = toClean.replaceAll("/$", "");
+		}
+
+		return toClean;
+	}
+
+}

--- a/src/main/java/org/syncany/plugins/dropbox/UriBuilder.java
+++ b/src/main/java/org/syncany/plugins/dropbox/UriBuilder.java
@@ -57,7 +57,7 @@ public class UriBuilder {
 		toClean = toClean.replaceAll("/{2,}", "/");
 
 		if (!endingSeparator) {
-			toClean = toClean.replaceAll("/$", "");
+			toClean = toClean.replaceAll("^(.+)/$", "$1");
 		}
 
 		return toClean;

--- a/src/test/java/org/syncany/plugins/dropbox/UriBuilderTest.java
+++ b/src/test/java/org/syncany/plugins/dropbox/UriBuilderTest.java
@@ -15,7 +15,6 @@ public class UriBuilderTest {
 
 	@Test
 	public void testLinuxStyleSeparator() {
-
 		assertEquals(URI.create("/a"), UriBuilder.fromRoot("/a").build());
 		assertEquals(URI.create("/a/"), UriBuilder.fromRoot("/a").withEndingSeparator().build());
 
@@ -30,12 +29,10 @@ public class UriBuilderTest {
 
 		assertEquals(URI.create("/a/b/"), UriBuilder.fromRoot("/a").toChild("/b").withEndingSeparator().build());
 		assertEquals(URI.create("/a/b/"), UriBuilder.fromRoot("/a").toChild("/b/").withEndingSeparator().build());
-
 	}
 
 	@Test
 	public void testWindowsStyleSeparator() {
-
 		assertEquals(URI.create("/a"), UriBuilder.fromRoot("\\a").build());
 		assertEquals(URI.create("/a/"), UriBuilder.fromRoot("\\a").withEndingSeparator().build());
 
@@ -50,7 +47,6 @@ public class UriBuilderTest {
 
 		assertEquals(URI.create("/a/b/"), UriBuilder.fromRoot("\\a").toChild("\\b").withEndingSeparator().build());
 		assertEquals(URI.create("/a/b/"), UriBuilder.fromRoot("\\a").toChild("\\b\\").withEndingSeparator().build());
-
 	}
 
 }

--- a/src/test/java/org/syncany/plugins/dropbox/UriBuilderTest.java
+++ b/src/test/java/org/syncany/plugins/dropbox/UriBuilderTest.java
@@ -49,4 +49,11 @@ public class UriBuilderTest {
 		assertEquals(URI.create("/a/b/"), UriBuilder.fromRoot("\\a").toChild("\\b\\").withEndingSeparator().build());
 	}
 
+	@Test
+	public void testEmptyUris() {
+		assertEquals(URI.create("/"), UriBuilder.fromRoot("/").build());
+		assertEquals(URI.create("/"), UriBuilder.fromRoot("//").build());
+		assertEquals(URI.create("/"), UriBuilder.fromRoot("/").toChild("/").build());
+		assertEquals(URI.create("/"), UriBuilder.fromRoot("//").toChild("/").build());
+	}
 }

--- a/src/test/java/org/syncany/plugins/dropbox/UriBuilderTest.java
+++ b/src/test/java/org/syncany/plugins/dropbox/UriBuilderTest.java
@@ -1,0 +1,56 @@
+package org.syncany.plugins.dropbox;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+
+import org.junit.Test;
+
+/**
+ * @author Christian Roth <christian.roth@port17.de>
+ */
+
+
+public class UriBuilderTest {
+
+	@Test
+	public void testLinuxStyleSeparator() {
+
+		assertEquals(URI.create("/a"), UriBuilder.fromRoot("/a").build());
+		assertEquals(URI.create("/a/"), UriBuilder.fromRoot("/a").withEndingSeparator().build());
+
+		assertEquals(URI.create("/a/b"), UriBuilder.fromRoot("/a").toChild("b").build());
+		assertEquals(URI.create("/a/b/"), UriBuilder.fromRoot("/a").toChild("b").withEndingSeparator().build());
+
+		assertEquals(URI.create("/a/b/c"), UriBuilder.fromRoot("/a").toChild("b").toChild("c").build());
+		assertEquals(URI.create("/a/b/c/"), UriBuilder.fromRoot("/a").toChild("b").toChild("c").withEndingSeparator().build());
+
+		assertEquals(URI.create("/a/b"), UriBuilder.fromRoot("/a").toChild("/b").build());
+		assertEquals(URI.create("/a/b"), UriBuilder.fromRoot("/a").toChild("/b/").build());
+
+		assertEquals(URI.create("/a/b/"), UriBuilder.fromRoot("/a").toChild("/b").withEndingSeparator().build());
+		assertEquals(URI.create("/a/b/"), UriBuilder.fromRoot("/a").toChild("/b/").withEndingSeparator().build());
+
+	}
+
+	@Test
+	public void testWindowsStyleSeparator() {
+
+		assertEquals(URI.create("/a"), UriBuilder.fromRoot("\\a").build());
+		assertEquals(URI.create("/a/"), UriBuilder.fromRoot("\\a").withEndingSeparator().build());
+
+		assertEquals(URI.create("/a/b"), UriBuilder.fromRoot("\\a").toChild("b").build());
+		assertEquals(URI.create("/a/b/"), UriBuilder.fromRoot("\\a").toChild("b").withEndingSeparator().build());
+
+		assertEquals(URI.create("/a/b/c"), UriBuilder.fromRoot("\\a").toChild("b").toChild("c").build());
+		assertEquals(URI.create("/a/b/c/"), UriBuilder.fromRoot("\\a").toChild("b").toChild("c").withEndingSeparator().build());
+
+		assertEquals(URI.create("/a/b"), UriBuilder.fromRoot("\\a").toChild("\\b").build());
+		assertEquals(URI.create("/a/b"), UriBuilder.fromRoot("\\a").toChild("\\b\\").build());
+
+		assertEquals(URI.create("/a/b/"), UriBuilder.fromRoot("\\a").toChild("\\b").withEndingSeparator().build());
+		assertEquals(URI.create("/a/b/"), UriBuilder.fromRoot("\\a").toChild("\\b\\").withEndingSeparator().build());
+
+	}
+
+}


### PR DESCRIPTION
Created an UriBuilder to create Uris pointing to a file within a Dropbox
account. Dropbox does not like Uris beginning with '//', although, that
seems to be ok with Uri itself. Especially took care that it is very
robust since it is taking user input.
Also added a test to verify the generated Uris (looks fine from here).

fixes syncany/syncany#417
