### PR TITLE
Use UriBuilder instead of Paths.get to build remote paths

### DIFF
--- a/src/main/java/org/syncany/plugins/dropbox/DropboxTransferManager.java
+++ b/src/main/java/org/syncany/plugins/dropbox/DropboxTransferManager.java
@@ -287,7 +287,9 @@ public class DropboxTransferManager extends AbstractTransferManager {
 			logger.log(Level.WARNING, "TransferManager is annotated with @PathAware but files do not possess path aware attributes");
 		}
 
-		return Paths.get(rootPath, subfolder, remoteFile.getName()).toString();
+		UriBuilder builder = UriBuilder.fromRoot(rootPath);
+		builder.toChild(subfolder).toChild(remoteFile.getName());
+		return builder.build().toString();
 	}
 
 	@Override


### PR DESCRIPTION
This avoids dropbox plugin breaking on windows because Paths.get will
use directory separator as `\` instead of `/`