### PR TITLE
Fix listFolder for empty folders

### DIFF
--- a/src/main/java/org/syncany/plugins/dropbox/DropboxTransferManager.java
+++ b/src/main/java/org/syncany/plugins/dropbox/DropboxTransferManager.java
@@ -423,6 +423,9 @@ public class DropboxTransferManager extends AbstractTransferManager {
 
 			try {
 				DbxEntry.WithChildren listing = transferManager.client.getMetadataWithChildren(path);
+				if (listing == null || listing.children == null) {
+					return contents;
+				}
 
 				for (DbxEntry child : listing.children) {
 					if (child.isFile()) {


### PR DESCRIPTION
On dropbox api [1] they state that: If there is no file or folder at the given path it will return null.
[1] https://dropbox.github.io/dropbox-sdk-java/api-docs/v1.6.x/com/dropbox/core/DbxClient.html#getMetadataWithChildren(java.lang.String)